### PR TITLE
increased restart wait period to 6 seconds

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -28,7 +28,7 @@
 
 - name: Pause to ensure Telegraf service is up
   pause:
-    seconds: 3
+    seconds: 6 
   when: telegraf_started.changed and telegraf_start_service
   
 - name: Collect service status


### PR DESCRIPTION
Telegraf 12.0 fails to complete the initial restart in 3 seconds in several tests so the wait time has been increased to 6 seconds, in order to counter that.
