### PR TITLE
dependencies should not be a child of galaxy_info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,4 +21,4 @@ galaxy_info:
         - wheezy
   categories:
     - monitoring
-  dependencies: []
+dependencies: []


### PR DESCRIPTION
I'm using an older version of ansible 1.9.2 that complains about this formatting. 

```
File "/usr/bin/ansible-galaxy", line 845, in execute_install
     role_dependencies = role_data['dependencies']
 KeyError: 'dependencies'
```

See related issues https://github.com/openstack-ansible-galaxy/openstack-keystone/pull/1

and https://github.com/ansible/ansible/issues/8892

and https://github.com/jameskyle/ansible-gentoo/commit/092e683597f0af7eddc8e8f8b9755b3468b6fd05

which helped me figure out and fix this. 
