### PR TITLE
changed for possible duplicate input plugins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,28 +24,33 @@ telegraf_influxdb_password:
 telegraf_influxdb_user_agent: 
 telegraf_influxdb_udp_payload: 512
 
-# Plugins to enable at runtime
-telegraf_plugins_enabled:
-  - cpu
-  - disk
-  - io
-  - mem
-  - swap
-  - system
-  
-telegraf_plugin_settings:
-  cpu:
-    percpu: "true"
-    totalcpu: "true"
-    drop:
-      - cpu_time
-  disk:
-    mountpoints:
-      - "/"
-  io:
-    skip_serial_number: "true"
-  procstat:
-    specifications:
-      exe: influxd
-      prefix: influxdb
+telegraf_plugins:
+  - name: mem
+  - name: system
+  - name: cpu
+    options:
+      percpu: "true"
+      totalcpu: "true"
+      drop:
+        - cpu_time
+  - name: disk
+    options: 
+      mountpoints:
+        - "/"
+  - name: io
+    options:
+      skip_serial_number: "true"
+  - name: procstat
+    options:
+      exe: "influxd"
+      prefix: "influxdb"
+  - name: procstat
+    options:
+      pid_file: "/var/lib/neo4j/data/neo4j-service.pid"
+      prefix: "neo4j_proc"
+
+  - name: net
+    options:
+      interfaces:
+        - "eth0"
 

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -90,24 +90,20 @@
 #                                  PLUGINS                                    #
 ###############################################################################
 
-{% for plugin in telegraf_plugins_enabled %}
-[[inputs.{{ plugin }}]]
-{% if telegraf_plugin_settings.get(plugin) != None %}
-{% for key, value in telegraf_plugin_settings.get(plugin).iteritems() %}
+{% for plugin in telegraf_plugins %}
+[[inputs.{{ plugin.name }}]]
+{% if plugin.options is defined %}
+{% for key, value in plugin.options.iteritems() %}
 {% if value is mapping  %}
-  [[plugins.{{ plugin }}.{{ key }}]]
-{% for key, value in value.iteritems() %}
-{% if value is mapping  %}
-    [[plugins.{{ plugin }}.{{ key }}]]
+  [plugins.{{ plugin.name }}.{{ key }}]
+{% for lv2_key, lv2_value in value.iteritems() %}
+{% if lv2_value is sequence and lv2_value is not string %}
+      {{ lv2_key }} = [ "{{ lv2_value|join('", "') }}" ]
 {% else %}
-{% if value is sequence and value is not string %}
-      {{ key }} = [ "{{ value|join('", "') }}" ]
+{% if lv2_value == "true" or lv2_value == "false" or lv2_value is number %}
+      {{ lv2_key }} = {{ lv2_value }}
 {% else %}
-{% if value == "true" or value == "false" or value is number %}
-      {{ key }} = {{ value }}
-{% else %}
-      {{ key }} = "{{ value }}"
-{% endif %}
+      {{ lv2_key }} = "{{ lv2_value }}"
 {% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
This fixes two issues:
Embedded mappings should be single brackets and not double. example:

```
[[inputs.cpu]]
  percpu = true
  totalcpu = false
  fielddrop = ["cpu_time"]
  # Don't collect CPU data for cpu6 & cpu7
  [inputs.cpu.tagdrop]
    cpu = [ "cpu6", "cpu7" ]
```

Now plugins are a list, not a mapping anymore, so we can have two plugins with the same name. Useful when you want `procstat` from many processes. Example:

```
[[inputs.procstat]]
  exe = "influxd"
  prefix = "influxd"

[[inputs.procstat]]
  pid_file = "/var/run/lxc/dnsmasq.pid"
```

An example working variable file:

```

---
# Channel of Telegraf to install
telegraf_install_version: stable

# Configuration Variables
telegraf_tags:

telegraf_agent_interval: 5s
telegraf_round_interval: "true"

telegraf_flush_interval: 10s
telegraf_flush_jitter: 0s
telegraf_debug: "false"
telegraf_hostname: 
telegraf_influxdb_database: 'monitoring'
telegraf_influxdb_urls:
  - http://192.168.13.37:8086
telegraf_influxdb_precision: s

telegraf_influxdb_timeout: 5s
telegraf_influxdb_username: 'admin'
telegraf_influxdb_password: 'admin'
telegraf_influxdb_user_agent: 
telegraf_influxdb_udp_payload: 512

# Plugins to enable at runtime
telegraf_plugins:
  - name: mem
  - name: system
  - name: cpu
    options:
      percpu: "true"
      totalcpu: "true"
      drop:
        - cpu_time
      tags:
        tag1: toto
        tag2: titi
  - name: disk
    options: 
      mountpoints:
        - "/benchmarkpool"
        - "/var/lib/neo4j"
  - name: io
    options:
      skip_serial_number: "true"

  - name: procstat
    options:
      pid_file: "/var/run/vertx-entcore.pid"
      prefix: "vertx-entcore_proc"
  - name: procstat
    options:
      pid_file: "/var/lib/neo4j/data/neo4j-service.pid"
      prefix: "neo4j_proc"

  - name: net
    options:
      interfaces:
        - "eth0"

```

PS: please take notice of  `telegraf_plugins_settings` name and type change and `telegraf_plugins_settings` deletion.

Fixes #5 
