### PR TITLE
Make influxdata base url a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,3 +65,5 @@ telegraf_plugins:
     options:
       interfaces:
         - "eth0"
+
+telegraf_influxdata_base_url: "https://repos.influxdata.com"

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -13,13 +13,13 @@
 
 - name: Import InfluxData GPG signing key [Debian/Ubuntu]
   apt_key:
-    url: https://repos.influxdata.com/influxdb.key
+    url: "{{ telegraf_influxdata_base_url }}/influxdb.key"
     state: present
   when: telegraf_install_url is not defined or telegraf_install_url == None
 
 - name: Add InfluxData repository [Debian/Ubuntu]
   apt_repository:
-    repo: deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ telegraf_install_version }}
+    repo: deb {{ telegraf_influxdata_base_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} {{ telegraf_install_version }}
     state: present
   when: telegraf_install_url is not defined or telegraf_install_url == None
 

--- a/templates/etc/yum.repos.d/influxdata.repo.j2
+++ b/templates/etc/yum.repos.d/influxdata.repo.j2
@@ -1,7 +1,7 @@
 [influxdb]
 name = InfluxDB Repository - {{ ansible_distribution }} $releasever
-baseurl = https://repos.influxdata.com/{{ ansible_distribution|lower }}/$releasever/$basearch/{{ telegraf_install_version }}
+baseurl = {{ telegraf_influxdata_base_url }}/{{ ansible_distribution|lower }}/$releasever/$basearch/{{ telegraf_install_version }}
 enabled = 1
 gpgcheck = 1
-gpgkey = https://repos.influxdata.com/influxdb.key
+gpgkey = {{ telegraf_influxdata_base_url }}/influxdb.key
 sslverify = 1


### PR DESCRIPTION
Thanks so much for developing and maintaining the ansible role. Purpose of the PR is to make it possible to use a mirror (e.x.:  https://mirrors.tuna.tsinghua.edu.cn/influxdata/ ). A user may just need to overwrite the`telegraf_influxdata_base_url` variable.
