### PR TITLE
Made role idempotent

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,7 @@
 ## group 'check status' and 'assert running' into a single listener
 - name: check status
   command: service telegraf status
-  ignore_errors: no
+  ignore_errors: yes
   register: telegraf_service_status
 - name: assert running
   assert:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,21 @@
 ---
+# The order here matters
 - name: restart telegraf
-  service: 
+  service:
     name: telegraf
     state: restarted
 
 - name: pause
   pause:
     seconds: 3
+
+## After version 2.2 of ansible 'listen' could be used to
+## group 'check status' and 'assert running' into a single listener
+- name: check status
+  command: service telegraf status
+  ignore_errors: no
+  register: telegraf_service_status
+- name: assert running
+  assert:
+    that:
+      - "telegraf_service_status.rc == 0"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,7 @@
 
 - name: pause
   pause:
-    seconds: 3
+    seconds: "{{telegraf_start_delay}}"
 
 ## After version 2.2 of ansible 'listen' could be used to
 ## group 'check status' and 'assert running' into a single listener

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,6 +9,12 @@
     group: telegraf
     mode: 0744
   when: telegraf_template_configuration
+  # If config changes, restart telegraf and confirm it remained running
+  notify:
+    - "restart telegraf"
+    - "pause"
+    - "check status"
+    - "assert running"
 
 - name: Test for sysvinit script
   stat:
@@ -31,28 +37,3 @@
 - name: Reload systemd configuration [systemd]
   command: systemctl daemon-reload
   when: telegraf_unit_file_updated is defined and telegraf_unit_file_updated.changed
-
-- name: Start the Telegraf service
-  service:
-    name: telegraf
-    state: restarted
-    enabled: yes
-  register: telegraf_started
-  when: telegraf_start_service
-
-- name: Pause to ensure Telegraf service is up
-  pause:
-    seconds: 6
-  when: telegraf_started.changed and telegraf_start_service
-
-- name: Collect service status
-  command: service telegraf status
-  register: telegraf_service_status
-  when: telegraf_start_service
-  ignore_errors: yes
-
-- name: Assert status of Telegraf service
-  assert:
-    that:
-      - "telegraf_service_status.rc == 0"
-  when: telegraf_start_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,3 +4,7 @@
 
 - include: configure.yml
   tags: [telegraf, configure]
+
+- include: start.yml
+  tags: [telegraf, start]
+  when: telegraf_start_service

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -1,0 +1,11 @@
+
+- name: Start the Telegraf service
+  service:
+    name: telegraf
+    state: started
+    enabled: yes
+  # Only care to check the status if the state changed to 'started'
+  notify:
+    - "pause"
+    - "check status"
+    - "assert running"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,7 @@ is_vagrant: no
 
 # If yes, service will be started. Will not be started if set to no.
 telegraf_start_service: yes
+telegraf_start_delay: 6
 
 # If yes, will overwrite the packaged configuration with an Asnible/jinja2 template
 telegraf_template_configuration: yes


### PR DESCRIPTION
1. Broke out a separate start.yml task so that `when: telegraf_start_service` is only in main.yaml
2. There was a `handlers/main.yml already` but it wasn't used - I added notify events for anything that should not run unless a change event happens
   - Configuration - only restart the service if it changed
   - Status Check - only pause and check running status if service was (re)started
