### PR TITLE
Added conditional on telegraf_start_service for pre-baked AMIs.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,10 +4,12 @@
   service:
     name: telegraf
     state: restarted
+  when: telegraf_start_service
 
 - name: pause
   pause:
     seconds: "{{telegraf_start_delay}}"
+  when: telegraf_start_service
 
 ## After version 2.2 of ansible 'listen' could be used to
 ## group 'check status' and 'assert running' into a single listener
@@ -15,7 +17,10 @@
   command: service telegraf status
   ignore_errors: yes
   register: telegraf_service_status
+  when: telegraf_start_service
+
 - name: assert running
   assert:
     that:
       - "telegraf_service_status.rc == 0"
+  when: telegraf_start_service


### PR DESCRIPTION
Hi Ross, I've used your module to provision Telegraf on pre-baked EC2 instances. These baked instances need services not started, so I've added the existing flag to the handler tasks. As you're calling these tasks from a notify in a template task, had to add this conditional to all the tasks being notified. Hope this helps, let me know any question you may have, thank you.