### PR TITLE
Added the option to add the ec2 tags to the telegraf tags

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@ telegraf_install_version: stable
 
 # Configuration Variables
 telegraf_tags:
+telegraf_aws_tags: false
+telegraf_aws_tags_prefix:
 
 telegraf_agent_interval: 10s
 telegraf_round_interval: "true"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,16 @@
 ---
+- name: Retrieve ec2 facts
+  ec2_facts:
+  when: telegraf_aws_tags
+
+- name: Retrieve all ec2 tags on the instance
+  ec2_tag:
+    region: '{{ ansible_ec2_placement_region }}'
+    resource: '{{ ansible_ec2_instance_id }}'
+    state: list
+  when: telegraf_aws_tags
+  register: ec2_tags
+
 - name: Set templatized Telegraf configuration
   template:
     src: telegraf.conf.j2

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -26,6 +26,11 @@
    {{ key }} = "{{ value }}"
 {% endfor %}
 {% endif %}
+{% if telegraf_aws_tags == true and ec2_tags is defined and ec2_tags != None %}
+{% for key, value in ec2_tags.tags.iteritems()%}
+   {{telegraf_aws_tags_prefix}}{{ key }} = "{{ value }}"
+{% endfor %}
+{% endif %}
 
 # Configuration for telegraf agent
 [agent]


### PR DESCRIPTION
Hi, I wanted to add all my ec2 tags to the influxdb tags in order to filter them later on.
I created a very simple solution for it.