### PR TITLE
Allow user to add their own plugins easily

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ telegraf_influxdb_password:
 telegraf_influxdb_user_agent:
 telegraf_influxdb_udp_payload:
 
-telegraf_plugins:
+telegraf_plugins_base:
   - name: mem
   - name: system
   - name: cpu
@@ -65,5 +65,7 @@ telegraf_plugins:
     options:
       interfaces:
         - "eth0"
+
+telegraf_plugins: "{{ telegraf_plugins_base }} + {{ telegraf_plugins_extra | default([]) }}"
 
 telegraf_influxdata_base_url: "https://repos.influxdata.com"


### PR DESCRIPTION
This way, users can add their own variables in their playbooks for example:
```
telegraf_plugins_extra:
      - name: docker
        options:
          endpoint: "unix:///var/run/docker.sock"
          timeout: "5s"
```