### PR TITLE
Override systemd unit user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,10 @@
 # Channel of Telegraf to install
 telegraf_install_version: stable
 
+# The user and group telegraf should run under (should be set to telegraf unless needed otherwise)
+telegraf_runas_user: telegraf
+telegraf_runas_group: telegraf
+
 # Configuration Variables
 telegraf_tags:
 telegraf_aws_tags: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -41,8 +41,16 @@
   command: sed -i s/GROUP=.*/GROUP={{ telegraf_runas_group }}/ /etc/init.d/telegraf
   when: telegraf_runas_group != "telegraf" and telegraf_sysvinit_script.stat.exists
 
+- name: Create systemd service directory [systemd]
+  file:
+    path: /etc/systemd/system/telegraf.service.d
+    state: directory
+  when: telegraf_runas_user != "telegraf" and not telegraf_sysvinit_script.stat.exists
+
 - name: Modify user Telegraf should run as [systemd]
-  command: sed -i s/User=.*/User={{ telegraf_runas_user }}/ /usr/lib/systemd/system/telegraf.service
+  template:
+    src: etc/systemd/system/telegraf.service.d/override.conf
+    dest: /etc/systemd/system/telegraf.service.d/override.conf
   when: telegraf_runas_user != "telegraf" and not telegraf_sysvinit_script.stat.exists
   register: telegraf_unit_file_updated
 

--- a/templates/systemd/system/telegraf.service.d/override.conf
+++ b/templates/systemd/system/telegraf.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+User={{ telegraf_runas_user }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,7 +14,3 @@ telegraf_template_configuration: yes
 # Path for finding Telegraf data. Added for backwards-compatibility.
 telegraf_binary_path: /usr/bin/telegraf
 telegraf_configuration_dir: /etc/telegraf
-
-# The user and group telegraf should run under (should be set to telegraf unless needed otherwise)
-telegraf_runas_user: telegraf
-telegraf_runas_group: telegraf


### PR DESCRIPTION
I need to run telegraf as root for collect procstat io (see influxdata/telegraf#1300).
I want to change `telegraf_runas_user` without modifing of role, so I moved this variable to `defaults/main.yml`.

Also, Ubuntu 16.04 places systemd config for telegraf at `/lib/systemd/system/telegraf.service` (see #18).

I used more reliable way to change systemd service user: override user with file placed at `/etc/systemd/system/telegraf.service.d/override.conf`.

When I just replaced user in `/lib/systemd/system/telegraf.service`, I got failing service start after `apt-get upgrade` (it reverts user to `telegraf` when telegraf updated).

Right way is call `systemctl edit telegraf.service`, it creates `/etc/systemd/system/telegraf.service.d/override.conf` that preserved between service upgrades.

Fixes #18.