### PR TITLE
Start and restart telegraf using sudo

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,7 @@
   service:
     name: telegraf
     state: restarted
+  become: true
   when: telegraf_start_service
 
 - name: pause
@@ -17,6 +18,7 @@
   command: service telegraf status
   ignore_errors: yes
   register: telegraf_service_status
+  become: true
   when: telegraf_start_service
 
 - name: assert running

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -9,3 +9,4 @@
     - "pause"
     - "check status"
     - "assert running"
+  become: true


### PR DESCRIPTION
Using Amazon Linux 2. Somehow this is the only I can get the playbook run successfully. Without sudo, the playbook always failed with error:

`fatal: [10.116.145.22]: FAILED! => {"changed": false, "msg": "Unable to restart service telegraf: Failed to restart telegraf.service: The name org.freedesktop.PolicyKit1 was not provided by any .service files\nSee system logs and 'systemctl status telegraf.service' for details.\n"}`