### PR TITLE
Suppress Ansible 'service' command warning

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,6 +16,8 @@
 ## group 'check status' and 'assert running' into a single listener
 - name: check status
   command: service telegraf status
+  args:
+    warn: false
   ignore_errors: yes
   register: telegraf_service_status
   become: true


### PR DESCRIPTION
Ansible 2.6 raises a warning when the service binary is called from the 'command' module. This change suppresses this warning while checking the status of telegraf.