### PR TITLE
Fix insecure_skip_verify value in telegraf config

### DIFF
--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -130,9 +130,9 @@
   # ssl_key = "{{ telegraf_influxdb_ssl_key }}"
 {% endif %}
 
-  ## Use SSL but skip chain & host verification
 {% if telegraf_influxdb_insecure_skip_verify is defined and telegraf_influxdb_insecure_skip_verify != None %}
-  # insecure_skip_verify = telegraf_influxdb_insecure_skip_verify
+  ## Use SSL but skip chain & host verification
+  insecure_skip_verify = {{ telegraf_influxdb_insecure_skip_verify }}
 {% endif %}
 
 ###############################################################################


### PR DESCRIPTION
Curly braces were missing, this fixes that.

Also I uncommented the line, otherwise if you set it to `true` a manual operation is needed in each server.