### PR TITLE
Update influxdata.repo.j2

### DIFF
--- a/templates/etc/yum.repos.d/influxdata.repo.j2
+++ b/templates/etc/yum.repos.d/influxdata.repo.j2
@@ -4,6 +4,8 @@ name = InfluxDB Repository - {{ ansible_distribution }} $releasever
 baseurl = "{{ telegraf_influxdata_base_url }}/centos/6/amd64/{{ telegraf_install_version }}"
 {% elif ansible_distribution|lower == "redhat" %}
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
+{% elif ansible_distribution|lower == "oraclelinux" %}
+baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
 {% else %}
 baseurl = {{ telegraf_influxdata_base_url }}/{{ ansible_distribution|lower }}/$releasever/$basearch/{{ telegraf_install_version }}
 {% endif %}


### PR DESCRIPTION
Fix install for oracle linux, previous version generates /etc/yum.repos.d/influxdata.repo

baseurl = https://repos.influxdata.com/oraclelinux/$releasever/$basearch/stable