### PR TITLE
Bullseye support

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -2,7 +2,6 @@
 - name: Install any necessary dependencies [Debian/Ubuntu]
   apt:
     name:
-      - python-httplib2
       - python-apt
       - curl
       - apt-transport-https

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -2,7 +2,7 @@
 - name: Install any necessary dependencies [Debian/Ubuntu]
   apt:
     name:
-      - python-apt
+      - python3-apt
       - curl
       - apt-transport-https
     state: present

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -3,7 +3,6 @@
   apt:
     name:
       - python3-apt
-      - curl
       - apt-transport-https
     state: present
     update_cache: yes


### PR DESCRIPTION
Fixes https://github.com/rossmcdonald/telegraf/issues/53

- `httplib2` appears not to be explicitly needed
- Update to `python3-apt`
- Remove `curl`, which also appears not to be used.