### PR TITLE
Simplify and make TOML config rendering more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 *deb
 *rpm
 playbooks/
+__pycache__

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ An Ansible role to install, configure, and manage [Telegraf](https://github.com/
 Requirements
 ------------
 
-Prior knowledge/experience with InfluxDB and Telegraf is highly recommended. Full documentation is available [here](https://docs.influxdata.com).
+- Module [toml](https://pypi.org/project/toml/) installed on the host running Ansible.
+- Prior knowledge/experience with InfluxDB and Telegraf is highly recommended. Full documentation is available [here](https://docs.influxdata.com).
 
 Installation
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,30 +52,28 @@ telegraf_influxdb_organization:
 telegraf_influxdb_bucket:
 
 telegraf_plugins_base:
-  - name: mem
-  - name: system
-  - name: cpu
-    options:
-      percpu: "true"
-      totalcpu: "true"
+  mem: [{}]
+  system: [{}]
+  cpu:
+    - percpu: true
+      totalcpu: true
       fielddrop:
         - "time_*"
-  - name: disk
-    options:
-      mountpoints:
+  disk:
+    - mountpoints:
         - "/"
-  - name: diskio
-    options:
-      skip_serial_number: "true"
-  - name: procstat
-    options:
-      exe: "influxd"
+  diskio:
+    - skip_serial_number: true
+  procstat:
+    - exe: "influxd"
       prefix: "influxdb"
-  - name: net
-    options:
-      interfaces:
+  net:
+    - interfaces:
         - "eth0"
 
-telegraf_plugins: "{{ telegraf_plugins_base }} + {{ telegraf_plugins_extra | default([]) }}"
+telegraf_plugins_extra:
+
+# The `combine()` filter requires Ansible 2.0
+telegraf_plugins: "{{ telegraf_plugins_base | combine(telegraf_plugins_extra) }}"
 
 telegraf_influxdata_base_url: "https://repos.influxdata.com"

--- a/filter_plugins/to_toml.py
+++ b/filter_plugins/to_toml.py
@@ -1,0 +1,9 @@
+import toml
+
+
+class FilterModule(object):
+    def filters(self):
+        return {"to_toml": self.to_toml}
+
+    def to_toml(self, input):
+        return toml.dumps(input)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install and configure Telegraf, the plugin-driven server agent for reporting metrics into InfluxDB
   company: InfluxData
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: 2.0
   platforms:
     - name: EL
       versions:

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -157,48 +157,8 @@
 #                                  PLUGINS                                    #
 ###############################################################################
 
-{% for plugin in telegraf_plugins %}
-[[inputs.{{ plugin.name }}]]
-{% if plugin.options is defined %}
-{% for key, value in plugin.options.items() %}
-{% if value is not mapping %}
-{% if value is sequence and value is not string %}
-{% if value[0] is number %}
-    {{ key }} = [ {{ value|join(', ') }} ]
-{% else %}
-    {{ key }} = [ "{{ value|join('", "') }}" ]
-{% endif %}
-{% else %}
-{% if value == "true" or value == "false" or value is number %}
-    {{ key }} = {{ value | lower }}
-{% else %}
-    {{ key }} = "{{ value }}"
-{% endif %}
-{% endif %}
-{% endif %}
-{% endfor %}
-{% for key, value in plugin.options.items() %}
-{% if value is mapping %}
-    [inputs.{{ plugin.name }}.{{ key }}]
-{% for lv2_key, lv2_value in value.items() %}
-{% if lv2_value is sequence and lv2_value is not string %}
-{% if lv2_value[0] is number %}
-      {{ lv2_key }} = [ {{ lv2_value|join(', ') }} ]
-{% else %}
-      {{ lv2_key }} = [ "{{ lv2_value|join('", "') }}" ]
-{% endif %}
-{% else %}
-{% if lv2_value == "true" or lv2_value == "false" or lv2_value is number %}
-      {{ lv2_key }} = {{ lv2_value | lower }}
-{% else %}
-      {{ lv2_key }} = "{{ lv2_value }}"
-{% endif %}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% endfor %}
+{% set inputs = dict(inputs=telegraf_plugins) %}
+{{ inputs | to_toml | replace('[inputs]', '') }}
 
 ###############################################################################
 #                              service PLUGINS                                #


### PR DESCRIPTION
I was trying to configure [SNMP plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/snmp/README.md) and discovered that the current Role Vars schema doesn't support the following part:

```
  [[inputs.snmp.field]]
    oid = "RFC1213-MIB::sysUpTime.0"
    name = "uptime"

  [[inputs.snmp.field]]
    oid = "RFC1213-MIB::sysName.0"
    name = "source"
```

So, instead of using the template syntax to render a correct toml config we use here a custom filter which converts yaml to toml. Such an approach considerably simplifies the template and allows to create complex configurations. There are some minor downsides though:

1. The custom filter requires [toml](https://pypi.org/project/toml/) module installed on the machine running Ansible.
2. I had to bump the `min_ansible_version` to `2.0`.

@rossmcdonald What do you think?
