### PR TITLE
Add support for Fedora and Rocky Linux

### DIFF
--- a/templates/etc/yum.repos.d/influxdata.repo.j2
+++ b/templates/etc/yum.repos.d/influxdata.repo.j2
@@ -6,6 +6,8 @@ baseurl = "{{ telegraf_influxdata_base_url }}/centos/6/amd64/{{ telegraf_install
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
 {% elif ansible_distribution|lower == "oraclelinux" %}
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
+{% elif ansible_distribution|lower == "rocky" %}
+baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
 {% elif ansible_distribution|lower == "fedora" %}
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/{{ '8' if ansible_distribution_major_version|int >= 28 else '7' }}/$basearch/{{ telegraf_install_version }}
 {% else %}

--- a/templates/etc/yum.repos.d/influxdata.repo.j2
+++ b/templates/etc/yum.repos.d/influxdata.repo.j2
@@ -6,6 +6,8 @@ baseurl = "{{ telegraf_influxdata_base_url }}/centos/6/amd64/{{ telegraf_install
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
 {% elif ansible_distribution|lower == "oraclelinux" %}
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
+{% elif ansible_distribution|lower == "fedora" %}
+baseurl = {{ telegraf_influxdata_base_url }}/rhel/{{ '8' if ansible_distribution_major_version|int >= 28 else '7' }}/$basearch/{{ telegraf_install_version }}
 {% else %}
 baseurl = {{ telegraf_influxdata_base_url }}/{{ ansible_distribution|lower }}/$releasever/$basearch/{{ telegraf_install_version }}
 {% endif %}


### PR DESCRIPTION
Only tested for real with fedora 34 but I used the information from [here](https://docs.fedoraproject.org/en-US/quick-docs/fedora-and-red-hat-enterprise-linux/index.html) to determine which Fedora version gets which Centos repo.