### PR TITLE
stlye: fix ansible-lint errors

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,7 +18,7 @@
   command: service telegraf status
   args:
     warn: false
-  ignore_errors: yes
+  ignore_errors: true
   register: telegraf_service_status
   become: true
   when: telegraf_start_service

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,6 @@ galaxy_info:
       versions:
         - jessie
         - wheezy
-  categories:
+  galaxy_tags:
     - monitoring
 dependencies: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,8 +15,8 @@
   template:
     src: "{{ telegraf_configuration_template }}"
     dest: "{{ telegraf_configuration_dir }}/telegraf.conf"
-    force: yes
-    backup: yes
+    force: true
+    backup: true
     owner: telegraf
     group: telegraf
     mode: 0744
@@ -51,16 +51,18 @@
   file:
     path: /etc/systemd/system/telegraf.service.d
     state: directory
+    mode: 0744
   when: telegraf_runas_user != "telegraf" and not telegraf_sysvinit_script.stat.exists
 
 - name: Modify user Telegraf should run as [systemd]
   template:
     src: systemd/system/telegraf.service.d/override.conf
     dest: /etc/systemd/system/telegraf.service.d/override.conf
+    mode: 0744
   when: telegraf_runas_user != "telegraf" and not telegraf_sysvinit_script.stat.exists
   register: telegraf_unit_file_updated
 
 - name: Reload systemd configuration [systemd]
   systemd:
-    daemon_reload: yes
+    daemon_reload: true
   when: telegraf_unit_file_updated is defined and telegraf_unit_file_updated.changed

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -5,7 +5,7 @@
       - python3-apt
       - apt-transport-https
     state: present
-    update_cache: yes
+    update_cache: true
     cache_valid_time: 3600
   register: apt_result
   until: apt_result is success
@@ -27,8 +27,8 @@
 - name: Install Telegraf packages [Debian/Ubuntu]
   apt:
     name: telegraf
-    state: latest
-    update_cache: yes
+    state: present
+    update_cache: true
     cache_valid_time: 3600
   register: apt_result
   until: apt_result is success

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -3,15 +3,16 @@
   template:
     src: etc/yum.repos.d/influxdata.repo.j2
     dest: /etc/yum.repos.d/influxdata.repo
-    force: yes
-    backup: yes
+    force: true
+    backup: true
+    mode: 0644
   when: telegraf_install_url is not defined or telegraf_install_url == None
 
 - name: Install Telegraf packages [RHEL/CentOS]
   yum:
     name: telegraf
-    state: latest
-    update_cache: yes
+    state: present
+    update_cache: true
   when: telegraf_install_url is not defined or telegraf_install_url == None
 
 - name: Install Telegraf from URL [RHEL/CentOS]

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -3,7 +3,7 @@
   service:
     name: telegraf
     state: started
-    enabled: yes
+    enabled: true
   # Only care to check the status if the state changed to 'started'
   notify:
     - "pause"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,14 +2,14 @@
 
 # Whether or not the playbook is run locally
 # This should only be set in the Vagrantfile and not modified elsewhere
-is_vagrant: no
+is_vagrant: false
 
 # If yes, service will be started. Will not be started if set to no.
-telegraf_start_service: yes
+telegraf_start_service: true
 telegraf_start_delay: 6
 
 # If yes, will overwrite the packaged configuration with an Asnible/jinja2 template
-telegraf_template_configuration: yes
+telegraf_template_configuration: true
 
 # Path for finding Telegraf data. Added for backwards-compatibility.
 telegraf_binary_path: /usr/bin/telegraf


### PR DESCRIPTION
I have telegraf role installed in my playbook and when I run command ansible-lint I get the following warning:

```
yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/handlers/main.yml:21

meta-no-tags: Use 'galaxy_tags' rather than 'categories'
../../../.ansible/roles/rossmcdonald.telegraf/meta/main.yml:1

role-name: Role name rossmcdonald.telegraf does not match ``^[a-z][a-z0-9_]+$`` pattern
../../../.ansible/roles/rossmcdonald.telegraf/meta/main.yml:1

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/configure.yml:18

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/configure.yml:19

risky-file-permissions: File permissions unset or incorrect
../../../.ansible/roles/rossmcdonald.telegraf/tasks/configure.yml:50 Task/Handler: Create systemd service directory 

risky-file-permissions: File permissions unset or incorrect
../../../.ansible/roles/rossmcdonald.telegraf/tasks/configure.yml:56 Task/Handler: Modify user Telegraf should run as 

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/configure.yml:65

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/install-debian.yml:8

package-latest: Package installs should not use latest
../../../.ansible/roles/rossmcdonald.telegraf/tasks/install-debian.yml:27 Task/Handler: Install Telegraf packages [Debian/Ubuntu]

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/install-debian.yml:31

risky-file-permissions: File permissions unset or incorrect
../../../.ansible/roles/rossmcdonald.telegraf/tasks/install-redhat.yml:2 Task/Handler: Add InfluxData repository file [RHEL/CentOS]

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/install-redhat.yml:6

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/install-redhat.yml:7

package-latest: Package installs should not use latest
../../../.ansible/roles/rossmcdonald.telegraf/tasks/install-redhat.yml:10 Task/Handler: Install Telegraf packages [RHEL/CentOS]

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/install-redhat.yml:14

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/tasks/start.yml:6

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/vars/main.yml:5

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/vars/main.yml:8

yaml: truthy value should be one of [false, true] (truthy)
../../../.ansible/roles/rossmcdonald.telegraf/vars/main.yml:12
```