### PR TITLE
Fix for 'str object' has no attribute 'name'

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,6 +3,7 @@ warn_list:
   - '106'
   - '503'
   - experimental
+  - name[template] # at least for now we won't deal with this
 skip_list:
   - risky-file-permissions
   - 'role-name'

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,10 @@
+---
+warn_list:
+  - '106'
+  - '503'
+  - experimental
+skip_list:
+  - risky-file-permissions
+  - 'role-name'
+  - 'fqcn-builtins'
+  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+---
+name: CI
+'on':
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 7 * * 2"
+
+defaults:
+  run:
+    working-directory: 'filviu.telegraf'
+
+jobs:
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'filviu.telegraf'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install yamllint
+
+      - name: Lint code.
+        run: |
+          yamllint .
+
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - centos8
+          - centos7
+          - rocky8
+          - ubuntu2204
+          - ubuntu2004
+          - ubuntu1804
+          - debian11
+          - debian10
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'filviu.telegraf'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule[docker] docker
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         distro:
           - centos8
           - centos7
-          - rocky8
+#          - rocky8 # geerling doesn't publish a docker rocky image
           - ubuntu2204
           - ubuntu2004
           - ubuntu1804

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+---
+# This workflow requires a GALAXY_API_KEY secret present in the GitHub
+# repository or organization.
+#
+# See: https://github.com/marketplace/actions/publish-ansible-role-to-galaxy
+# See: https://github.com/ansible/galaxy/issues/46
+
+name: Release
+'on':
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    working-directory: 'filviu.telegraf'
+
+jobs:
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'filviu.telegraf'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible.
+        run: pip3 install ansible-base
+
+      - name: Trigger a new import on Galaxy.
+        run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ telegraf_runas_group: telegraf
 
 # Configuration Template
 telegraf_configuration_template: telegraf.conf.j2
+telegraf_configuration_backup: true
 
 # Configuration Variables
 telegraf_tags:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,6 @@ telegraf_plugins_base:
       interfaces:
         - "eth0"
 
-telegraf_plugins: "{{ telegraf_plugins_base }} + {{ telegraf_plugins_extra | default([]) }}"
+telegraf_plugins: "{{ telegraf_plugins_base + telegraf_plugins_extra | default([]) }}"
 
 telegraf_influxdata_base_url: "https://repos.influxdata.com"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,9 +15,8 @@
 ## After version 2.2 of ansible 'listen' could be used to
 ## group 'check status' and 'assert running' into a single listener
 - name: check status
-  ansible.builtin.command: service telegraf status
-  args:
-    warn: false
+  ansible.builtin.command: 
+    cmd: service telegraf status
   ignore_errors: true
   register: telegraf_service_status
   become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 # The order here matters
 - name: restart telegraf
-  service:
+  ansible.builtin.service:
     name: telegraf
     state: restarted
   become: true
@@ -15,7 +15,7 @@
 ## After version 2.2 of ansible 'listen' could be used to
 ## group 'check status' and 'assert running' into a single listener
 - name: check status
-  command: service telegraf status
+  ansible.builtin.command: service telegraf status
   args:
     warn: false
   ignore_errors: true
@@ -24,7 +24,7 @@
   when: telegraf_start_service
 
 - name: assert running
-  assert:
+  ansible.builtin.assert:
     that:
       - "telegraf_service_status.rc == 0"
   when: telegraf_start_service

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
-  author: Ross McDonald
-  description: Install and configure Telegraf, the plugin-driven server agent for reporting metrics into InfluxDB
+  author: filviu
+  description: Install and configure Telegraf, the plugin-driven server agent for reporting metrics into InfluxDB. Original by Ross McDonald. Forked to speedup needed fixes and development.
   company: InfluxData
   license: MIT
   min_ansible_version: 1.2
@@ -12,13 +12,13 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
-        - trusty
-        - utopic
-        - vivid
+        - jammy
+        - focal
+        - bionic
     - name: Debian
       versions:
-        - jessie
-        - wheezy
+        - bullseye
+        - buster
   galaxy_tags:
     - monitoring
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,24 +1,25 @@
 ---
+dependencies: []
+
 galaxy_info:
+  role_name: telegraf
   author: filviu
   description: Install and configure Telegraf, the plugin-driven server agent for reporting metrics into InfluxDB. Original by Ross McDonald. Forked to speedup needed fixes and development.
-  company: InfluxData
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: "1.2"
   platforms:
     - name: EL
       versions:
-        - 6
-        - 7
+        - "6"
+        - "7"
     - name: Ubuntu
       versions:
-        - jammy
-        - focal
-        - bionic
+        - "jammy"
+        - "focal"
+        - "bionic"
     - name: Debian
       versions:
-        - bullseye
-        - buster
+        - "bullseye"
+        - "buster"
   galaxy_tags:
     - monitoring
-dependencies: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,7 @@
 
   pre_tasks:
     - name: Update apt cache.
-      apt: update_cache=true cache_valid_time=600
+      ansible.builtin.apt: update_cache=true cache_valid_time=600
       when: ansible_os_family == 'Debian'
 
     - name: Install test dependencies (Debian).
@@ -16,7 +16,7 @@
       when: ansible_os_family == 'Debian'
 
     - name: Install test dependencies (RedHat).
-      package: name=which state=present
+      ansible.builtin.package: name=which state=present
       when: ansible_os_family == 'RedHat'
 
   roles:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,7 +9,10 @@
       when: ansible_os_family == 'Debian'
 
     - name: Install test dependencies (Debian).
-      apt: name=gpg state=present
+      ansible.builtin.package:
+        name:
+          - gpg
+          - gpg-agent
       when: ansible_os_family == 'Debian'
 
     - name: Install test dependencies (RedHat).

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,6 +8,10 @@
       apt: update_cache=true cache_valid_time=600
       when: ansible_os_family == 'Debian'
 
+    - name: Install test dependencies (Debian).
+      apt: name=gpg state=present
+      when: ansible_os_family == 'Debian'
+
     - name: Install test dependencies (RedHat).
       package: name=which state=present
       when: ansible_os_family == 'RedHat'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,16 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=true cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+    - name: Install test dependencies (RedHat).
+      package: name=which state=present
+      when: ansible_os_family == 'RedHat'
+
+  roles:
+    - role: filviu.telegraf

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: instance
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    ansible.builtin.command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: instance
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
-    ansible.builtin.command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,5 +6,5 @@
   gather_facts: false
   tasks:
   - name: Example assertion
-    assert:
+    ansible.builtin.assert:
       that: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,7 +16,7 @@
     src: "{{ telegraf_configuration_template }}"
     dest: "{{ telegraf_configuration_dir }}/telegraf.conf"
     force: true
-    backup: true
+    backup: "{{ telegraf_configuration_backup }}"
     owner: telegraf
     group: telegraf
     mode: 0744

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,7 +12,7 @@
   register: ec2_tags
 
 - name: Set templatized Telegraf configuration
-  template:
+  ansible.builtin.template:
     src: "{{ telegraf_configuration_template }}"
     dest: "{{ telegraf_configuration_dir }}/telegraf.conf"
     force: true
@@ -29,33 +29,33 @@
     - "assert running"
 
 - name: Test for sysvinit script
-  stat:
+  ansible.builtin.stat:
     path: /etc/init.d/telegraf
   register: telegraf_sysvinit_script
 
 - name: Modify user Telegraf should run as [sysvinit]
-  replace:
+  ansible.builtin.replace:
     path: /etc/init.d/telegraf
     regexp: USER=.*
-    replace: USER={{ telegraf_runas_user }}
+    ansible.builtin.replace: USER={{ telegraf_runas_user }}
   when: telegraf_runas_user != "telegraf" and telegraf_sysvinit_script.stat.exists
 
 - name: Modify group Telegraf should run as [sysvinit]
-  replace:
+  ansible.builtin.replace:
     path: /etc/init.d/telegraf
     regexp: GROUP=.*
-    replace: GROUP={{ telegraf_runas_group }}
+    ansible.builtin.replace: GROUP={{ telegraf_runas_group }}
   when: telegraf_runas_group != "telegraf" and telegraf_sysvinit_script.stat.exists
 
 - name: Create systemd service directory [systemd]
-  file:
+  ansible.builtin.file:
     path: /etc/systemd/system/telegraf.service.d
     state: directory
     mode: 0744
   when: telegraf_runas_user != "telegraf" and not telegraf_sysvinit_script.stat.exists
 
 - name: Modify user Telegraf should run as [systemd]
-  template:
+  ansible.builtin.template:
     src: systemd/system/telegraf.service.d/override.conf
     dest: /etc/systemd/system/telegraf.service.d/override.conf
     mode: 0744

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install any necessary dependencies [Debian/Ubuntu]
-  apt:
+  ansible.builtin.apt:
     name:
       - python3-apt
       - apt-transport-https
@@ -25,7 +25,7 @@
   when: telegraf_install_url is not defined or telegraf_install_url == None
 
 - name: Install Telegraf packages [Debian/Ubuntu]
-  apt:
+  ansible.builtin.apt:
     name: telegraf
     state: present
     update_cache: true
@@ -43,7 +43,7 @@
   when: telegraf_install_url is defined and telegraf_install_url != None
 
 - name: Install downloaded Telegraf package [Debian/Ubuntu]
-  apt:
+  ansible.builtin.apt:
     deb: /tmp/telegraf-ansible-download.deb
     state: present
   register: apt_result

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -14,7 +14,7 @@
 
 - name: Import InfluxData GPG signing key [Debian/Ubuntu]
   apt_key:
-    url: "{{ telegraf_influxdata_base_url }}/influxdb.key"
+    url: "{{ telegraf_influxdata_base_url }}/influxdata-archive_compat.key"
     state: present
   when: telegraf_install_url is not defined or telegraf_install_url == None
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add InfluxData repository file [RHEL/CentOS]
-  template:
+  ansible.builtin.template:
     src: etc/yum.repos.d/influxdata.repo.j2
     dest: /etc/yum.repos.d/influxdata.repo
     force: true

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -1,6 +1,6 @@
 ---
 - name: Start the Telegraf service
-  service:
+  ansible.builtin.service:
     name: telegraf
     state: started
     enabled: true

--- a/templates/etc/yum.repos.d/influxdata.repo.j2
+++ b/templates/etc/yum.repos.d/influxdata.repo.j2
@@ -6,6 +6,8 @@ baseurl = "{{ telegraf_influxdata_base_url }}/centos/6/amd64/{{ telegraf_install
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
 {% elif ansible_distribution|lower == "oraclelinux" %}
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
+{% elif ansible_distribution|lower == "almalinux" %}
+baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
 {% elif ansible_distribution|lower == "rocky" %}
 baseurl = {{ telegraf_influxdata_base_url }}/rhel/$releasever/$basearch/{{ telegraf_install_version }}
 {% elif ansible_distribution|lower == "fedora" %}

--- a/templates/etc/yum.repos.d/influxdata.repo.j2
+++ b/templates/etc/yum.repos.d/influxdata.repo.j2
@@ -17,5 +17,5 @@ baseurl = {{ telegraf_influxdata_base_url }}/{{ ansible_distribution|lower }}/$r
 {% endif %}
 enabled = 1
 gpgcheck = 1
-gpgkey = {{ telegraf_influxdata_base_url }}/influxdb.key
+gpgkey = {{ telegraf_influxdata_base_url }}/influxdata-archive_compat.key
 sslverify = 1


### PR DESCRIPTION
I started seeing the following error:

```shell
TASK [rossmcdonald.telegraf : Set templatized Telegraf configuration] *************************************************************************************************************************************************
task path: /home/user/.ansible/roles/rossmcdonald.telegraf/tasks/configure.yml:14
The full traceback is:
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/ansible/template/__init__.py", line 1116, in do_template
    res = ansible_concat(rf)
  File "/home/user/.local/lib/python3.10/site-packages/ansible/template/native_helpers.py", line 88, in ansible_concat
    return ''.join([to_text(v) for v in nodes])
  File "/home/user/.local/lib/python3.10/site-packages/ansible/template/native_helpers.py", line 88, in <listcomp>
    return ''.join([to_text(v) for v in nodes])
  File "<template>", line 231, in root
  File "/home/user/.local/lib/python3.10/site-packages/ansible/template/__init__.py", line 268, in wrapper
    ret = func(*args, **kwargs)
  File "/home/user/.local/lib/python3.10/site-packages/ansible/template/__init__.py", line 647, in _ansible_finalize
    return thing if _fail_on_undefined(thing) is not None else ''
  File "/home/user/.local/lib/python3.10/site-packages/ansible/template/__init__.py", line 619, in _fail_on_undefined
    elif is_sequence(data):
  File "/home/user/.local/lib/python3.10/site-packages/ansible/module_utils/common/collections.py", line 94, in is_sequence
    if not include_strings and is_string(seq):
  File "/home/user/.local/lib/python3.10/site-packages/jinja2/runtime.py", line 852, in _fail_with_undefined_error
    raise self._undefined_exception(self._undefined_message)
jinja2.exceptions.UndefinedError: 'str object' has no attribute 'name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/ansible/plugins/action/template.py", line 138, in run
    resultant = templar.do_template(template_data, preserve_trailing_newlines=True, escape_backslashes=False)
  File "/home/user/.local/lib/python3.10/site-packages/ansible/template/__init__.py", line 1153, in do_template
    raise AnsibleUndefinedVariable(e)
ansible.errors.AnsibleUndefinedVariable: 'str object' has no attribute 'name'
fatal: [dev17.smartkyc.com]: FAILED! => changed=false 
  msg: 'AnsibleUndefinedVariable: ''str object'' has no attribute ''name'''
```

I am not sure at which point this started happening - I only discovered when I wanted to add a new telegraf plugin to my infrastructure. By the looks of it the result of the old style concatenation results in a string now instead of a list. This fixes the issue for me but I didn't test more than this.