### PR TITLE
tasks: Update tasks to latest syntax.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
-- include: install-redhat.yml
+- include_tasks: install-redhat.yml
   when: ansible_os_family == "RedHat"
 
-- include: install-debian.yml
+- include_tasks: install-debian.yml
   when: ansible_os_family == "Debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- include: install.yml
+- import_tasks: install.yml
   tags: [telegraf, install]
 
-- include: configure.yml
+- import_tasks: configure.yml
   tags: [telegraf, configure]
 
-- include: start.yml
+- import_tasks: start.yml
   tags: [telegraf, start]
   when: telegraf_start_service


### PR DESCRIPTION
include has been deprecated and removed. We should be using include_tasks or import_task